### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/SPIE2016-9913-16/9913-16.tex
+++ b/SPIE2016-9913-16/9913-16.tex
@@ -11,7 +11,7 @@
 
 \newcommand{\ascl}[1]{\href{http://www.ascl.net/#1}{ascl:#1}}
 \newcommand{\arxiv}[1]{\href{http://arxiv.org/abs/#1}{arXiv:#1}}
-\newcommand{\doi}[1]{\href{http://dx.doi.org/#1}{doi:#1}}
+\newcommand{\doi}[1]{\href{https://doi.org/#1}{doi:#1}}
 
 \usepackage{xspace}
 

--- a/SPIE2016-9913-16/lsst-astropy.bib
+++ b/SPIE2016-9913-16/lsst-astropy.bib
@@ -355,7 +355,7 @@ booktitle = {Astronomical Data Analysis Software and Systems XIX},
    number = "2",
    pages = "31-39",
    url = "http://scitation.aip.org/content/aip/journal/cise/13/2/10.1109/MCSE.2010.118",
-   doi = "http://dx.doi.org/10.1109/MCSE.2010.118"
+   doi = "https://doi.org/10.1109/MCSE.2010.118"
 }
 
 @ARTICLE{2011SchpJ...611404H,
@@ -771,7 +771,7 @@ booktitle = "Proceedings of the 14th Python in Science Conference",
    volume = "15",
     pages = "33 - 49",
      year = "2016",
-      doi = "http://dx.doi.org/10.1016/j.ascom.2016.02.003",
+      doi = "https://doi.org/10.1016/j.ascom.2016.02.003",
       url = "http://www.sciencedirect.com/science/article/pii/S2213133716300129",
    author = "David S. Berry and Rodney F. Warren-Smith and Tim Jenness",
 }
@@ -783,7 +783,7 @@ booktitle = "Proceedings of the 14th Python in Science Conference",
   year         = 2016,
   note         = {\doi{10.5281/zenodo.48435}},
   doi          = {10.5281/zenodo.48435},
-  url          = {http://dx.doi.org/10.5281/zenodo.48435}
+  url          = {https://doi.org/10.5281/zenodo.48435}
 }
 
 @inproceedings{2016SPIE-Kahn,
@@ -843,7 +843,7 @@ booktitle = {Python in Astronomy 2016},
      year = 2016,
     month = mar,
      note = {\doi{10.5281/zenodo.50991}},
-      url = {http://dx.doi.org/10.5281/zenodo.50991},
+      url = {https://doi.org/10.5281/zenodo.50991},
       doi = {10.5281/zenodo.50991},
 }
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!

PS: Same as https://github.com/astropy/astropy/pull/7460 & other PRs there.
PPS: If I shall send PRs with the same link updates to your other `dmtn-0…` repos, please let me know.